### PR TITLE
setup new_label_tensor when there is not label files

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -56,7 +56,9 @@ def load_dataset(rel_path='.', mode="training", resize=False, resize_shape=(256,
         else:
             tmp = np.expand_dims(label, axis=0)
             label_tensor = np.concatenate((label_tensor, tmp), axis=0)
-    new_label_tensor = np.stack((label_tensor[:,:,:], 1 - label_tensor[:,:,:]), axis=1)
+    new_label_tensor = None
+    if mode == "training":
+        new_label_tensor = np.stack((label_tensor[:,:,:], 1 - label_tensor[:,:,:]), axis=1)
     
     for i, filename in enumerate(train_mask_files):
         print('[*] adding {}th {} mask : {}'.format(i+1, mode, filename))


### PR DESCRIPTION
When trying to replicate your code I had to do some fixes, this `test` mode was one of them. When running on `test` mode it does not create the `new_label_tensor` variable... but then this variable is required in the function root logic. I suppose you mostly used the `npy` logic in there? But that might have worked only if there was empty label files for test, or you used a different test dataset... full of assumptions here.

Hope this fix helps you